### PR TITLE
Map run data to an existing index

### DIFF
--- a/mongo_connector/plugin_manager.py
+++ b/mongo_connector/plugin_manager.py
@@ -1,0 +1,114 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+
+CLASS_NAME = 'className'
+CONFIG = 'config'
+MODULE_NAME = 'moduleName'
+OPTIONS = 'options'
+PLUGIN_NAME = 'pluginName'
+INDEX_DOCS = 'indexDocs'
+
+LOG = logging.getLogger(__name__)
+
+
+def _config_as_list(config):
+    """Returns the plugin config as a list.
+    """
+    if not config:
+        return []
+
+    if isinstance(config, list):
+        return config
+
+    return [config]
+
+
+def _resolve_plugin_config(config):
+    """Resolves plugin using the configuration.
+    """
+    LOG.debug('resolving plugin config %r', config)
+    if PLUGIN_NAME not in config:
+        return None
+
+    class_name = config[PLUGIN_NAME]
+    module_name = 'mongo_connector.plugins.%s_plugin' % class_name
+    if MODULE_NAME in config:
+        module_name = config[MODULE_NAME]
+
+    if CLASS_NAME in config:
+        class_name = config[CLASS_NAME]
+
+    #  Create a new plugin instance.
+    try:
+        # Resolve the plugin module.
+        # importlib doesn't exist in 2.6, but __import__ is everywhere
+
+        # import importlib
+        # module = importlib.import_module(module_name)
+        module = __import__(module_name, fromlist=(module_name,))
+        clz = getattr(module, class_name)
+
+        # Create a new plugin instance.
+        return clz(config)
+    except Exception as exc:
+        fqn = '%s.%s' % (module_name, class_name)
+        LOG.error('creating new plugin %s instance: %s', fqn, exc)
+
+    return None
+
+
+def get_plugin_configs(namespace):
+    """Returns the plugin configurations for a namespace.
+    """
+    LOG.debug('Getting plugin configs for %r', namespace)
+    if namespace and isinstance(namespace.plugins, list):
+        configs = []
+        for plugin_config in namespace.plugins:
+            if CONFIG in plugin_config:
+                configs.append(plugin_config)
+        return configs
+
+    return []
+
+
+def docs_index_needed(config):
+    """Returns whether or not any plugin config options say that docs need
+       to be indexed as well.
+    """
+    LOG.debug('checking if docs index needed for config %r', config)
+    for cfg in _config_as_list(config):
+        if cfg and CONFIG in cfg and OPTIONS in cfg[CONFIG]:
+            options = cfg[CONFIG][OPTIONS]
+            if INDEX_DOCS in options and options[INDEX_DOCS]:
+                LOG.debug('docs index needed returning true')
+                return True
+    return False
+
+
+def resolve(config):
+    """Resolves the plugins using the specified configuration.
+    """
+    LOG.debug('Resolving plugin config %r', config)
+    plugin_list = []
+    for cfg in _config_as_list(config):
+        plugin = _resolve_plugin_config(cfg)
+
+        # Even though plugin config was valid at check time, ensure that
+        # we only use "resolved" plugins.
+        if plugin is not None:
+            plugin_list.append(plugin)
+
+    return plugin_list

--- a/mongo_connector/plugins/__init__.py
+++ b/mongo_connector/plugins/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/mongo_connector/plugins/plugin_base.py
+++ b/mongo_connector/plugins/plugin_base.py
@@ -1,0 +1,78 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import logging
+import uuid
+
+
+#pylint: disable=R0921
+class PluginBase(object):
+    """Base class for all plugin implementations."""
+
+    def __init__(self, config=None):
+        """Initialize a plugin instance.
+        """
+        self._config = copy.deepcopy(config or {})
+        self._name = None
+        if isinstance(self._config, dict) and 'pluginName' in self._config:
+            self._name = self._config['pluginName']
+
+        if self._name is None:
+            self._name = 'generated-%s' % uuid.uuid4()
+
+        self.logger = logging.getLogger(__name__)
+        self.logger.debug('BasePlugin initializer called')
+        self.logger.debug('BasePlugin name = %s', self._name)
+        self.logger.debug('BasePlugin config = %r', self._config)
+
+
+    def name(self):
+        """Returns the name of the plugin.
+        """
+        return self._name
+
+
+    def info(self):
+        """Returns the plugin config information.
+        """
+        if isinstance(self._config, dict) and 'config' in self._config:
+            return self._config['config']
+        return {}
+
+
+    def invoke(self, operation, doc, manager):
+        """Invoke a plugin operator on a document.
+        """
+        raise NotImplementedError
+
+
+    def bulk_invoke(self, operation, docs, manager):
+        """Bulk invoke a plugin for a set of documents.
+
+        This method may be overridden to invoke many documents at once.
+        """
+        for doc in docs:
+            self.invoke(operation, doc, manager)
+
+
+    def commit(self):
+        """Commit any outstanding operations.
+        """
+        raise NotImplementedError
+
+
+    def stop(self):
+        """Stop threads if any are started by a plugin.
+        """
+        raise NotImplementedError

--- a/mongo_connector/plugins/plugin_simulator.py
+++ b/mongo_connector/plugins/plugin_simulator.py
@@ -1,0 +1,79 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+
+from mongo_connector.plugins.plugin_base import PluginBase
+
+INDEX = 'index'
+QUERY = 'query'
+UPDATE = 'update'
+OPTIONS = 'options'
+OPTIONS_ALLOW_DELETES_XPATH = '/%s/allowDeletes' % OPTIONS
+
+
+class PluginSimulator(PluginBase):
+    """Simulator plugin.
+    """
+
+    def __init__(self, config=None):
+        """Initialize the plugin instance.
+        """
+        self.ops = {}
+        self.stop_called = False
+        self.commit_called = False
+        super(self.__class__, self).__init__(config)
+
+
+    def find_ops(self, key):
+        """Returns all the ops for a specific key.
+        """
+        if key in self.ops:
+            return copy.deepcopy(self.ops[key])
+
+        return []
+
+
+    def is_stopped(self):
+        return self.stop_called
+
+
+    def is_committed(self):
+        return self.commit_called
+
+
+    def invoke(self, operation, doc, manager):
+        """Update an existing Elasticsearch index in the document manager
+           using the specified document.
+        """
+        if not isinstance(doc, dict) or '_id' not in doc:
+            return None
+
+        key = doc['_id']
+        if key not in self.ops:
+            self.ops[key] = []
+
+        self.ops[key].append({'op': operation, 'doc': doc})
+        return doc
+
+
+    def commit(self):
+        """Commit any outstanding operations.
+        """
+        self.commit_called = True
+
+
+    def stop(self):
+        """Stop threads if any are started by a plugin.
+        """
+        self.stop_called = True

--- a/mongo_connector/plugins/update_elasticsearch_index.py
+++ b/mongo_connector/plugins/update_elasticsearch_index.py
@@ -1,0 +1,256 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import threading
+import time
+
+from mongo_connector.plugins.plugin_base import PluginBase
+from mongo_connector.util import resolve_xpath
+
+
+INDEX = 'index'
+
+QUERY = 'query'
+QUERY_KEY_XPATH = '/%s/key' % QUERY
+QUERY_XMAP_XPATH = '/%s/xmap' % QUERY
+
+UPDATE = 'update'
+UPDATE_FIELD_XPATH = '/%s/field' % UPDATE
+UPDATE_KEY_XPATH = '/%s/key' % UPDATE
+UPDATE_XMAP_XPATH = '/%s/xmap' % UPDATE
+
+VALUE = 'value'
+UPDATE_VALUE_XPATH = '/%s/%s' % (UPDATE, VALUE)
+UPDATE_VALUE_TYPE_XPATH = '%s/type' % UPDATE_VALUE_XPATH
+UPDATE_VALUE_KEYS_XPATH = '%s/keys' % UPDATE_VALUE_XPATH
+
+OPTIONS = 'options'
+OPTIONS_ALLOW_DELETES_XPATH = '/%s/allowDeletes' % OPTIONS
+
+SUPPORTED_VALUE_TYPES = ['dict']
+
+LOG = logging.getLogger(__name__)
+
+
+# TODO(ramr): All this code eventually should be in a separate plugin repo.
+
+def _resolve_xmap(doc, xmap):
+    """Build and return the resolved xmap dictionary.
+    """
+    xmap_dict = {}
+    if isinstance(xmap, dict):
+        for k in xmap:
+            xmap_dict[k] = resolve_xpath(doc, xmap[k])
+
+    return xmap_dict
+
+
+def _build_query_key(doc, fields, xmap):
+    """Build and return the query key.
+    """
+    if fields is None or not isinstance(fields, list):
+        return None
+
+    if xmap is None or not isinstance(xmap, dict):
+        return None
+
+    xmap_dict = _resolve_xmap(doc, xmap)
+
+    query_key = ""
+    for k in fields:
+        if k in xmap_dict and xmap_dict[k] is not None:
+            query_key += xmap_dict[k]
+
+    if len(query_key) > 0:
+        return query_key
+
+    return None
+
+
+def _get_query_criteria(config, doc):
+    """Build and return the query criteria.
+    """
+    if not isinstance(config, dict) or QUERY not in config:
+        return None
+
+    key_fields = resolve_xpath(config, QUERY_KEY_XPATH)
+    if not isinstance(key_fields, list):
+        key_fields = [key_fields]
+
+    xmap = resolve_xpath(config, QUERY_XMAP_XPATH)
+    return _build_query_key(doc, key_fields, xmap)
+
+
+def _build_update_key(config, doc):
+    """Build the update key.
+    """
+    if not isinstance(config, dict) or UPDATE not in config:
+        return None
+
+    field_name = resolve_xpath(config, UPDATE_FIELD_XPATH)
+    xmap = resolve_xpath(config, UPDATE_XMAP_XPATH)
+    key_fields = resolve_xpath(config, UPDATE_KEY_XPATH)
+
+    if not isinstance(key_fields, list):
+        key_fields = [key_fields]
+
+    if field_name is None:
+        return None
+
+    if xmap is None or not isinstance(xmap, dict):
+        return None
+
+    xmap_dict = _resolve_xmap(doc, xmap)
+
+    update_key = "%s." % field_name
+    start_len = len(update_key)
+    for k in key_fields:
+        if k in xmap_dict and xmap_dict[k] is not None:
+            update_key += xmap_dict[k]
+
+    if len(update_key) == start_len:
+        return None
+
+    return update_key
+
+
+def _build_update_value_dict(config, doc):
+    """Build the update value dictionary.
+    """
+    if not isinstance(config, dict) or UPDATE not in config:
+        return None
+
+    xmap = resolve_xpath(config, UPDATE_XMAP_XPATH)
+    if xmap is None or not isinstance(xmap, dict):
+        return None
+
+    xmap_dict = _resolve_xmap(doc, xmap)
+
+    value_type = resolve_xpath(config, UPDATE_VALUE_TYPE_XPATH)
+    if value_type not in SUPPORTED_VALUE_TYPES:
+        return None
+
+    value_keys = resolve_xpath(config, UPDATE_VALUE_KEYS_XPATH)
+    if value_keys is None or not isinstance(value_keys, list):
+        return None
+
+    value_dict = {}
+    for k in value_keys:
+        if k in xmap_dict and xmap_dict[k] is not None:
+            value_dict[k] = xmap_dict[k]
+
+    if len(value_dict) > 0:
+        return value_dict
+
+    return None
+
+
+def _get_document_update_spec(operation, config, doc):
+    """Return the document update spec.
+    """
+    update_key = _build_update_key(config, doc)
+    allow_deletes = resolve_xpath(config, OPTIONS_ALLOW_DELETES_XPATH)
+
+    if operation == 'd':
+        if allow_deletes is True and update_key is not None:
+            return {"$unset": {update_key: True}}
+        return None
+
+    update_value_dict = _build_update_value_dict(config, doc)
+
+    if update_key is None or update_value_dict is None:
+        return None
+
+    return {"$set": {update_key: update_value_dict}}
+
+
+class UpdateElasticsearchIndex(PluginBase):
+    """Update Elasticsearch index plugin.
+    """
+
+    def __init__(self, config=None):
+        """Initialize update Elasticsearch index plugin instance.
+        """
+        self._pending_ops = []
+        self._lock = threading.Lock()
+        super(self.__class__, self).__init__(config)
+
+
+    def _add_pending_op(self, manager):
+        """Adds a pending operation.
+        """
+        self._lock.acquire()
+        self._pending_ops.append(manager)
+        self._lock.release()
+
+
+    def _reset_pending_ops(self):
+        """Resets any pending operations.
+        """
+        pending_ops = []
+
+        self._lock.acquire()
+        pending_ops = self._pending_ops or []
+        self._pending_ops = None
+        self._lock.release()
+
+        return pending_ops
+
+
+    def invoke(self, operation, doc, manager):
+        """Update an existing Elasticsearch index in the document manager
+           using the specified document.
+        """
+        self.logger.debug('UpdateElasticsearchIndex.invoke(%s, %s, %s)',
+            operation, doc, manager)
+
+        config = self.info()
+
+        index_name = None
+        if INDEX in config:
+            index_name = config[INDEX]
+
+        if index_name is None:
+            LOG.error('UpdateElasticsearchIndex.invoke: no index name')
+            return None
+
+        criteria = _get_query_criteria(config, doc)
+        update_spec = _get_document_update_spec(operation, config, doc)
+        timestamp = time.time()
+
+        if criteria is None or update_spec is None:
+            LOG.info('UpdateElasticsearchIndex.invoke: no criteria '
+                      'or update spec for %s operation', operation)
+            return None
+
+        LOG.debug('UpdateElasticsearchIndex.invoke: criteria = %s, '
+            'update_spec = %r, index_name = %s',
+            criteria, update_spec, index_name)
+
+        self._add_pending_op(manager)
+        return manager.update(criteria, update_spec, index_name, timestamp)
+
+
+    def commit(self):
+        """Commit any outstanding operations.
+        """
+        pending_doc_managers = self._reset_pending_ops()
+        for pdm in pending_doc_managers:
+            pdm.commit()
+
+
+    def stop(self):
+        """Stop threads if any are started by a plugin.
+        """
+        pass

--- a/mongo_connector/util.py
+++ b/mongo_connector/util.py
@@ -106,3 +106,21 @@ def log_fatal_exceptions(func):
             LOG.exception("Fatal Exception")
             raise
     return wrapped
+
+
+def resolve_xpath(d, xp):
+    """Resolves XPath 'xp' in dictionary 'd' and return the value."""
+    value = d
+    try:
+        # Strip the leading /.
+        xp = xp.strip("/")
+        for k in xp.split("/"):
+            try:
+                idx = int(k)
+                value = value[idx]
+            except ValueError:
+                value = value.get(k)
+    except:
+        value = None
+        pass
+    return value

--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/tests/plugins/helpers.py
+++ b/tests/plugins/helpers.py
@@ -1,0 +1,145 @@
+# Copyright 2013-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helper methods for plugins
+"""
+import sys
+
+sys.path[0:0] = [""]
+
+from mongo_connector.namespace_config import Namespace
+
+TEST_MODULES = [u'mongo_connector.plugins.plugin_simulator',
+                u'mongo_connector.plugins.update_elasticsearch_index']
+
+TEST_PLUGIN_CONFIGS = [{
+    u'pluginName': u'TestPlugin',
+    u'moduleName': u'mongo_connector.plugins.plugin_simulator',
+    u'className':  u'PluginSimulator',
+    u'config': {
+        u'index': u'ns1.resources',
+        u'query': {
+            u'key':  [u'_id'],
+            u'xmap': {
+                u'_id': u'/resourceId'
+            }
+        },
+        u'update': {
+            u'field': u'run_props',
+            u'key':   u'propid',
+            u'value': {
+                u'type': u'dict',
+                u'keys': [u'name', u'value']
+            },
+            u'xmap': {
+                u'propid': u'/propertyId',
+                u'name':   u'/propertyName',
+                u'value':  u'/data/0/value'
+            }
+        },
+        u'options': {
+            u'indexDocs':    False,
+            u'allowDeletes': True
+        }
+    }
+},
+{
+    u'pluginName': u'UpdateElasticsearchIndex',
+    u'moduleName': u'mongo_connector.plugins.update_elasticsearch_index',
+    u'config': {
+        u'index': u'ns1.resources',
+        u'query': {
+            u'key':  [u'_id'],
+            u'xmap': {
+                u'_id': u'/resourceId'
+            }
+        },
+        u'update': {
+            u'field': u'run_props',
+            u'key':   u'propid',
+            u'value': {
+                u'type': u'dict',
+                u'keys': [u'name', u'value']
+            },
+            u'xmap': {
+                u'propid': u'/propertyId',
+                u'name':   u'/propertyName',
+                u'value':  u'/data/0/value'
+            }
+        },
+        u'options': {
+            u'indexDocs':    False,
+            u'allowDeletes': True
+        }
+    }
+},
+{
+    u'pluginName': u'BadConfigPlugin',
+    u'moduleName': u'mongo_connector.plugins.update_elasticsearch_index'
+},
+{
+    u'pluginName': u'NonExistentPlugin',
+    u'moduleName': u'mongo_connector.plugins.does_not_exist',
+    u'config': {
+        u'index': u'ns1.something',
+        u'options': {
+            u'indexDocs':    True,
+            u'allowDeletes': True
+        }
+    }
+},
+{
+    u'pluginName': u'NoModuleAndNonExistentPlugin',
+    u'config': {
+        u'index': u'ns1.something',
+        u'options': {
+            u'indexDocs':    True,
+            u'allowDeletes': True
+        }
+    }
+}
+]
+
+BAD_PLUGIN_CONFIGS = [None, [], {}, {'foo': 1}, 1, 2.2, '3.33', 'four']
+
+TEST_DOCS = [{
+    '_id': 'one'
+},
+{
+    '_id': 'two',
+    'data': { 'value': 'jr' }
+},
+{
+    '_id': 'three.0',
+},
+{
+    '_id': 'four',
+    'data': { 'value': { 'arr': [1.1, 2.2, 3.3], 'str': 'quad', 'd': 4.0}}
+}]
+
+BAD_DOCS = [None, [], {}, {'no_id': 'five'}, 1, 2.2, '3.33', 'four']
+
+TEST_DOC_OPERATIONS = ['i', 'u', 'd', 'c']
+
+BAD_OPERATIONS = ['x', 'y', 'z']
+
+
+def get_test_namespace():
+    """Returns the Namespace for testing plugins."""
+    return Namespace(plugins=TEST_PLUGIN_CONFIGS)
+
+
+def get_test_supported_modules():
+    """Returns the plugin modules supported for testing purposes."""
+    return TEST_MODULES

--- a/tests/plugins/test_plugin_base.py
+++ b/tests/plugins/test_plugin_base.py
@@ -1,0 +1,115 @@
+# Copyright 2013-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests methods in plugin_base.py
+"""
+import copy
+import sys
+
+sys.path[0:0] = [""]
+
+from mongo_connector.plugins.plugin_base import PluginBase
+from tests import unittest
+from tests.plugins.helpers import (BAD_PLUGIN_CONFIGS, get_test_namespace)
+
+
+class TestPluginBase(unittest.TestCase):
+    """ Tests the utils
+    """
+
+    def setUp(self):
+        """Initialize test instance.
+        """
+        self.namespace = get_test_namespace()
+
+
+    def test_name(self):
+        """Test name.
+        """
+        configs = self.namespace.plugins[0]
+        for cfg in configs:
+            obj = PluginBase(cfg)
+            self.assertEqual(cfg['pluginName'], obj.name())
+
+        for cfg in BAD_PLUGIN_CONFIGS:
+            obj = PluginBase(cfg)
+            self.assertEqual(obj.name().index('generated'), 0)
+
+
+    def test_info(self):
+        """Test info.
+        """
+        configs = self.namespace.plugins[0]
+        for cfg in configs:
+            obj = PluginBase(cfg)
+            self.assertEqual(cfg['config'], obj.info())
+
+        for cfg in BAD_PLUGIN_CONFIGS:
+            obj = PluginBase(cfg)
+            self.assertEqual(obj.info(), {})
+
+
+    def _test_not_implemented_method_by_name(self, name):
+        """Test not implemented method by name.
+        """
+        configs = copy.deepcopy(self.namespace.plugins)
+        configs.extend(BAD_PLUGIN_CONFIGS)
+        for cfg in configs:
+            obj = PluginBase(cfg)
+            try:
+                method = getattr(obj, name)
+                if not method or not callable(method):
+                    raise KeyError
+
+                method()
+
+            except NotImplementedError as exc:
+                pass
+
+        return True
+
+
+    def test_invoke(self):
+        """Test invoke.
+        """
+        flag = self._test_not_implemented_method_by_name('invoke')
+        self.assertEqual(flag, True)
+
+
+    def test_bulk_invoke(self):
+        """Test bulk_invoke.
+        """
+        # Bulk invoke is really implemented but it calls invoke in loop
+        # which returns an not implemented exception.
+        flag = self._test_not_implemented_method_by_name('bulk_invoke')
+        self.assertEqual(flag, True)
+
+
+    def test_commit(self):
+        """Test commit.
+        """
+        flag = self._test_not_implemented_method_by_name('commit')
+        self.assertEqual(flag, True)
+
+
+    def test_stop(self):
+        """Test stop.
+        """
+        flag = self._test_not_implemented_method_by_name('stop')
+        self.assertEqual(flag, True)
+
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/tests/plugins/test_plugin_simulator.py
+++ b/tests/plugins/test_plugin_simulator.py
@@ -1,0 +1,130 @@
+# Copyright 2013-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests methods in plugin_base.py
+"""
+import copy
+import sys
+
+sys.path[0:0] = [""]
+
+from mongo_connector.plugins.plugin_simulator import PluginSimulator
+from tests import unittest
+from tests.plugins.helpers import (BAD_PLUGIN_CONFIGS,
+                                   TEST_DOCS,
+                                   BAD_DOCS,
+                                   TEST_DOC_OPERATIONS,
+                                   BAD_OPERATIONS,
+                                   get_test_namespace)
+
+
+class PluginSimulatorTest(unittest.TestCase):
+    """ Tests the PluginSimulator.
+    """
+
+    def setUp(self):
+        """Initialize test instance.
+        """
+        self.configs = copy.deepcopy(BAD_PLUGIN_CONFIGS)
+        for cfg in get_test_namespace().plugins:
+            if 'className' in cfg and cfg['className'] == 'PluginSimulator':
+                self.configs.append(cfg)
+
+
+    def test_instantiate(self):
+        """Test creation.
+        """
+        for cfg in self.configs:
+            plugin = PluginSimulator(cfg)
+            self.assertIsNotNone(plugin)
+            self.assertFalse(plugin.is_committed())
+            self.assertFalse(plugin.is_stopped())
+
+
+    def test_is_stopped(self):
+        """Test is_stopped.
+        """
+        for cfg in self.configs:
+            plugin = PluginSimulator(cfg)
+            self.assertIsNotNone(plugin)
+            self.assertFalse(plugin.is_stopped())
+            plugin.commit()
+            self.assertFalse(plugin.is_stopped())
+            plugin.stop()
+            self.assertTrue(plugin.is_stopped())
+
+
+    def test_is_committed(self):
+        """Test is_committed.
+        """
+        for cfg in self.configs:
+            plugin = PluginSimulator(cfg)
+            self.assertIsNotNone(plugin)
+            self.assertFalse(plugin.is_committed())
+            plugin.stop()
+            self.assertFalse(plugin.is_committed())
+            plugin.commit()
+            self.assertTrue(plugin.is_committed())
+
+
+    def test_invoke(self):
+        """Test invoke.
+        """
+        for cfg in self.configs:
+            plugin = PluginSimulator(cfg)
+            self.assertIsNotNone(plugin)
+            for doc in TEST_DOCS:
+                for op in TEST_DOC_OPERATIONS:
+                    self.assertIsNotNone(plugin.invoke(op, doc, {}))
+                    ops = plugin.find_ops(doc['_id'])
+                    lastop = ops.pop()
+                    self.assertEqual(lastop['op'], op)
+                    self.assertEqual(lastop['doc'], doc)
+
+                for op in BAD_OPERATIONS:
+                    self.assertIsNotNone(plugin.invoke(op, doc, {}))
+
+            for doc in BAD_DOCS:
+                for op in TEST_DOC_OPERATIONS:
+                    self.assertIsNone(plugin.invoke(op, doc, {}))
+
+                for op in BAD_OPERATIONS:
+                    self.assertIsNone(plugin.invoke(op, doc, {}))
+
+
+    def test_commit(self):
+        """Test commit.
+        """
+        for cfg in self.configs:
+            plugin = PluginSimulator(cfg)
+            self.assertIsNotNone(plugin)
+            self.assertFalse(plugin.is_committed())
+            plugin.commit()
+            self.assertTrue(plugin.is_committed())
+
+
+    def test_stop(self):
+        """Test stop.
+        """
+        for cfg in self.configs:
+            plugin = PluginSimulator(cfg)
+            self.assertIsNotNone(plugin)
+            self.assertFalse(plugin.is_stopped())
+            plugin.stop()
+            self.assertTrue(plugin.is_stopped())
+
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,0 +1,92 @@
+# Copyright 2013-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests methods in plugin_manager.py
+"""
+import sys
+
+sys.path[0:0] = [""]
+
+from mongo_connector.plugin_manager import (get_plugin_configs,
+                                            docs_index_needed,
+                                            resolve)
+from tests import unittest
+from tests.plugins.helpers import (get_test_namespace,
+                                   get_test_supported_modules)
+
+
+class TestPluginManager(unittest.TestCase):
+    """ Tests the plugin manager.
+    """
+
+    def setUp(self):
+        """Initialize test instance.
+        """
+        self.namespace = get_test_namespace()
+
+
+    def test_get_plugin_configs(self):
+        """Test get_plugin_configs."""
+        configs = get_plugin_configs(self.namespace)
+        self.assertEqual(len(configs), 4)
+        self.assertTrue(len(self.namespace.plugins) > len(configs))
+
+        for cfg in configs:
+            self.assertTrue(cfg['pluginName'] != u'BadConfigPlugin')
+
+
+    def test_docs_index_needed(self):
+        """Test docs_index_needed."""
+        configs = get_plugin_configs(self.namespace)
+        self.assertTrue(docs_index_needed(configs))
+        for cfg in configs:
+            expectation = False
+            if 'config' in cfg and 'options' in cfg['config']:
+                options = cfg['config']['options']
+                if 'indexDocs' in options:
+                   expectation = options['indexDocs']
+
+            docs_index = docs_index_needed(cfg)
+            self.assertEqual(docs_index, expectation)
+            docs_index = docs_index_needed([cfg])
+            self.assertEqual(docs_index, expectation)
+
+
+    def test_resolve(self):
+        """Test resolve."""
+        configs = get_plugin_configs(self.namespace)
+
+        plugins = resolve(configs)
+        self.assertEqual(len(plugins), 2)
+        self.assertTrue(len(self.namespace.plugins) > len(plugins))
+
+        plugins = resolve(configs[0:2])
+        self.assertEqual(len(plugins), 2)
+
+        supported = get_test_supported_modules()
+
+        for cfg in configs:
+            expectation = 0
+            if 'moduleName' in cfg and cfg['moduleName'] in supported:
+                expectation = 1
+
+            cfg_plugins = resolve(cfg)
+            self.assertEqual(len(cfg_plugins), expectation)
+            cfg_plugins = resolve([cfg])
+            self.assertEqual(len(cfg_plugins), expectation)
+
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -23,7 +23,8 @@ sys.path[0:0] = [""]
 
 from mongo_connector.util import (bson_ts_to_long,
                                   long_to_bson_ts,
-                                  retry_until_ok)
+                                  retry_until_ok,
+                                  resolve_xpath)
 from tests import unittest
 
 
@@ -94,6 +95,27 @@ class TestUtil(unittest.TestCase):
             retry_until_ok(err_func, RuntimeError)
         self.assertEqual(err_func.counter, 1)
 
+    def test_resolve_xpath(self):
+        """Test resolve_xpath."""
+
+        doc = {"_id": "foo", "resourceId": "bar", "propertyId": 123.456,
+               "propertyName": "manufacturer",
+               "data": [{"eventId": 0, "value": "GE"},
+                        {"eventId": 1, "value": "PHILLIPS"}],
+               "options": {"flag": True},
+        }
+
+        self.assertEqual(resolve_xpath(doc, "/_id"), "foo")
+        self.assertEqual(resolve_xpath(doc, "/propertyId"), 123.456)
+        self.assertEqual(resolve_xpath(doc, "/data/0/value"), "GE")
+        self.assertEqual(resolve_xpath(doc, "/data/1/eventId"), 1)
+        self.assertEqual(resolve_xpath(doc, "/options/flag"), True)
+        self.assertEqual(resolve_xpath(doc, "/_wrong"), None)
+        self.assertEqual(resolve_xpath(doc, "/propertyId/_wrong/_wronger"), None)
+        self.assertEqual(resolve_xpath(doc, "/data/99"), None)
+        self.assertEqual(resolve_xpath(doc, "/data/options"), None)
+        self.assertEqual(resolve_xpath(doc, "/data/99/options"), None)
+        self.assertEqual(resolve_xpath(doc, "/data/99/options/flag"), None)
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
@lnader  PTAL

This PR adds plugin capabilities to mongo-connector. A plugin is defined by its class name in the connector configuration (see a json snippet in https://gist.github.com/ramr/022229b65c8d77db9571a81c523b5984 for an example). 
And the plugin is referenced in the namespaces (collection/index) and the appropriate config is 
passed to it. 

The above example also shows to map fields from the mongo document into an existing
index updating a dictionary called additional_properties with a key and a value based on the `propertyId`, `propertyName` and `data` information. 

As an example, if the mongo runData collection contains 2 documents: 
```
db.runData.save({"_id": "RR-CHEBI_10-1", "resourceId": "CHEBI_10",
                 "propertyId": "metabolite_id",
                 "data" : [{"eventId": 0, "value": 1 },
                           {"eventId": 2, "value": 2 },
                           {"eventId": 3, "value": 3 }],
                 "propertyName" : "metabolite", "immutable": "true" })
db.runData.save({"_id": "RR-CHEBI_10-2", "resourceId": "CHEBI_10",
                 "propertyId": "alkaloid_id",
                 "data": [{"eventId": 0, "value": 1.1},
                          {"eventId": 2, "value": 2.2 },
                          {"eventId": 3, "value": 3.3 },
                          {"eventId": 4, "value": 4.4 }],
                 "propertyName" : "alkaloid", "immutable": "true" })
```

And the collection `meteor_namespace.resources` (I actually used resourceTypes in my configuration for testing as that collection had some data, the resources collection was empty).
```  has this entry: 

rs0:PRIMARY> db.resourceTypes.find({_id: "CHEBI_10"})
{ "_id" : "CHEBI_10", "definition" : "An isoquinoline that has formula C36H38N2O6.", "name" : "(+)-Atherospermoline", "parents" : [  {  "_id" : "CHEBI_24922",  "name" : "isoquinolines" } ], "ref" : "http://purl.obolibrary.org/obo/CHEBI_10", "source" : "CHEBI", "synonyms" : [  "(+)-Atherospermoline",  "XGEAUXVPBXUBKN-NSOVKSMOSA-N",  "C36H38N2O6" ] }
```

The `UpdateElasticsearchIndex` plugin will update the index in elastic search from the above info to also contain the new field `additional_properties` and will set the mapped entries in the dictionary 
appropriately - for the propertyIds `metabolite_id` and `alkaloid_id` as shown above. 
The updated index is shown in this gist: 
     https://gist.github.com/ramr/d831da01957b446186935a520db86e3c

So with this, we can now update an existing index in elasticsearch. 
As mentioned on the phone, I couldn't do this to an existing `properties` field as it was an array
entry - and so a bit troublesome as we need to know the index of the entry in order to update it when the runData collection changes.  And that makes it a wee bit ungainly and slower as we would have to read the existing index properties and then update the property in that array in its  proper position and then update the index). Instead this uses a dictionary, so that the key-value pair is easier to set/unset on update. 

Note this still needs some tests and will squash the commits so that it becomes easier when we upstream this. 

Could you also please email me some data - maybe 20-30 entries from the `resources` collection for testing. I will also send a corresponding PR for the meteor app side once I have some data for testing.

Thanks.