### PR TITLE
SEAR-82, Parameteize target host for elastic doc manager

### DIFF
--- a/config/connector_property_types.json
+++ b/config/connector_property_types.json
@@ -21,7 +21,6 @@
     "docManagers": [
         {
             "docManager": "elastic2_doc_manager",
-            "targetURL": "elastic-elasticsearch-client:9200",
             "bulkSize": 10000,
             "autoCommitInterval": 1,
             "args": {

--- a/config/connector_resource_types.json
+++ b/config/connector_resource_types.json
@@ -20,7 +20,6 @@
     "docManagers": [
         {
             "docManager": "elastic2_doc_manager",
-            "targetURL": "elastic-elasticsearch-client:9200",
             "bulkSize": 10000,
             "autoCommitInterval": 1,
             "args": {

--- a/config/connector_resources_and_run_data.json
+++ b/config/connector_resources_and_run_data.json
@@ -48,7 +48,6 @@
     "docManagers": [
         {
             "docManager": "elastic2_doc_manager",
-            "targetURL": "elastic-elasticsearch-client:9200",
             "bulkSize": 10000,
             "autoCommitInterval": 1,
             "args": {

--- a/scripts/elasticsearch-configure.sh
+++ b/scripts/elasticsearch-configure.sh
@@ -15,6 +15,7 @@ declare -A INDEX_TO_COLLECTION_MAP=( ["resource_types"]="resourceTypes"
 
 # expect INDEX_LIST environment variable to provide the list of ES indexes this instance of mongo-connector
 # should work for. Expect a single index name or a comma separated list
+# Eg: "resource_types"  or "resource_types,property_types,resources_and_run_data"
 INDEX_LIST=${INDEX_LIST:-""}
 
 echo "setting mongo-connector for indices ${INDEX_LIST}"

--- a/scripts/start-mongo-connector.sh
+++ b/scripts/start-mongo-connector.sh
@@ -4,6 +4,7 @@ bash elasticsearch-configure.sh -f
 
 # expect INDEX_LIST environment variable to provide the list of ES indexes this instance of mongo-connector
 # should work for. Expect a single index name or a comma separated list
+# Eg: "resource_types"  or " resource_types,property_types,resources_and_run_data"
 INDEX_LIST=${INDEX_LIST:-""}
 
 echo "setting mongo-connector for indices ${INDEX_LIST}"
@@ -16,6 +17,6 @@ for index in "${INDEX_ARRAY[@]}"
 do
     # $MONGO_HOSTS should be in format HOSTNAME:PORT
     # example mongodb01:27017,mongodb02:27017,mongodb03:27017
-    mongo-connector --auto-commit-interval=0 -m $MONGO_HOSTS -c config/connector_$index.json --stdout
+    mongo-connector --auto-commit-interval=0 -m $MONGO_HOSTS -c config/connector_$index.json -t $ELASTIC_HOST:$ELASTIC_PORT --stdout
     sleep 1
 done


### PR DESCRIPTION
Removed the hardcoded elasticsearch server address from connector configs and provide
ES host details from environment variables in the command line