### PR TITLE
SEAR-374: Change to use auto-commit-interval using env `AUTO_COMMIT_INTERVAL`....

### DIFF
--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -958,6 +958,7 @@ def get_config_options():
 
         # validate doc managers and fill in default values
         for dm in option.value:
+
             if not isinstance(dm, dict):
                 raise errors.InvalidConfiguration(
                     "Elements of docManagers must be a dict.")
@@ -965,6 +966,8 @@ def get_config_options():
                 raise errors.InvalidConfiguration(
                     "Every element of docManagers"
                     " must contain 'docManager' property.")
+            LOG.always("Document Manager settings")
+            LOG.always(dm)
             if not dm.get('targetURL'):
                 dm['targetURL'] = None
             if not dm.get('uniqueKey'):


### PR DESCRIPTION
.. , if defined. Otherwise it uses value from connector's config file. Also added settings to ignore python warnings 'Unverified HTTPS' as it was polluting the log.

