### PR TITLE
SEAR-403 enable search on public field of property types

### DIFF
--- a/config/mapping_property_types.json
+++ b/config/mapping_property_types.json
@@ -47,12 +47,13 @@
             "type": "text"
         },
         "immutable": {
-            "type": "boolean",
-            "index": true
+            "type": "boolean"
         },
         "deleted": {
-            "type": "boolean",
-            "index": true
+            "type": "boolean"
+        },
+        "public": {
+            "type": "boolean"
         },
         "accessibleTo": {
             "properties": {


### PR DESCRIPTION
Per https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-index.html, the `index` field defaults to `true` so is unnecessary to specify `inxex: true`