### PR TITLE
SEAR-410 remove synonym ngram mapping

### DIFF
--- a/config/mapping_resource_types.json
+++ b/config/mapping_resource_types.json
@@ -34,11 +34,6 @@
                     "analyzer": "nonword",
                     "index_options": "docs"
                 },
-                "ngram_resource_type": {
-                    "type": "text",
-                    "analyzer": "entity_name",
-                    "index_options": "docs"
-                },
                 "edge_ngram_resource_type": {
                     "type": "text",
                     "analyzer": "autocomplete1",

--- a/config/settings.json
+++ b/config/settings.json
@@ -62,7 +62,7 @@
 				"partial_match_tokenizer": {
 					"type": "ngram",
 					"min_gram": "3",
-					"max_gram": "30"
+					"max_gram": "10"
 				},
 				"my_whitespace_tokenizer": {
                     "type": "pattern",


### PR DESCRIPTION
In my testing this dramatically improved indexing and does not appear to break any of our test cases. The reason why is that it reduces the number of ngrams generated overall, plus it removes the ngram tokenizing on the synonyms, which are sometimes substantial. With these changes, mongo-connector no longer throws errors, I see no stalls in _cat/indices, and elasticsearch is no longer crashing with OOM errors, even with the 128m settings in values-dev. 

I am planning to try deploying to qa3 and testing on property types once Japheth clears the environment for use. 